### PR TITLE
fix msg.validated_value bug and ensure we will get alerts for similar bugs

### DIFF
--- a/whatsapp_business_api_is/bot_functions.py
+++ b/whatsapp_business_api_is/bot_functions.py
@@ -12,6 +12,8 @@ class Functions:
         try:
             set_data(user, data, msg)
         except Exception as e:
+            import traceback
+            traceback.print_exc()
             print(f" Failed to save data: {e}")
 
     @staticmethod

--- a/whatsapp_business_api_is/utils.py
+++ b/whatsapp_business_api_is/utils.py
@@ -176,7 +176,8 @@ def set_data(user, data, msg):
         obj = run_action(data.get('action'), user, msg, None, data)
 
     if 'field' in data:
-        value = data.get('value', msg.validated_value)
+        # we want an exception to be thrown if msg is None and data['value'] doesn't exist
+        value = data.get('value', msg.validated_value) if msg else data['value']
 
         logging.info(f"About to save data: {obj=} {data['field']=} {value=}")
         setattr(obj, data['field'], value)


### PR DESCRIPTION
When `msg` is `None`, this code raises `AttributeError` before even calling `get()`:

```
value = data.get('value', msg.validated_value)
```

Fixed.